### PR TITLE
Add a presubmit to check that the java builds.

### DIFF
--- a/.github/workflows/javabuild.yaml
+++ b/.github/workflows/javabuild.yaml
@@ -1,0 +1,16 @@
+name: Java Build
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build with Maven
+        run: mvn package --file pom.xml


### PR DESCRIPTION
This is an additional workflow that will run when you create a pull request to check that the Java you are adding will build.

From PR #1 you'll see that I didn't add this originally because pom.xml hadn't been created.  It has now, so now I'm doing this!