### PR TITLE
Autogenerate hints

### DIFF
--- a/src/main/webapp/go.css
+++ b/src/main/webapp/go.css
@@ -11,7 +11,7 @@
 }
 
 p {
-  font-size: 18px;
+  font-size: 14px;
 }
 
 .content {
@@ -28,7 +28,7 @@ p {
 }
 
 .riddle-row {
-  top: 20%;
+  top: 30%;
 }
 
 .button-row {
@@ -36,7 +36,10 @@ p {
 }
 
 .hint-row {
-  top: 70%;
+  border: 1px solid black;
+  margin: 10%;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 button,
@@ -71,14 +74,14 @@ button:hover a {
   -ms-transform: translate(-50%, -50%);
   background-color: #b47eb3;
   border-radius: 10px;
-  height: 50%;
+  bottom: 10px;
+  height: 40%;
   left: 50%;
-  margin-bottom: 20%;
+  margin-bottom: 0%;
   margin-top: 20%;
   padding-left: 100px;
-  padding-top: 50px;
-  position: absolute;
-  top: 50%;
+  padding-top: 300px;
+  position: relative;
   transform: translate(-50%, -50%);
   width: 70%;
 }
@@ -105,12 +108,17 @@ button:hover a {
 }
 
 #progress-area {
-  width: 70%;
   background-color: grey;
+  width: 70%;
 }
 
 #progress-bar {
-  width: 1%;
-  height: 30px;
   background-color: #e1f0c4;
+  height: 30px;
+  width: 1%;
+}
+
+#riddle-area p {
+  font-size: 22px;
+  font-weight: bold;
 }

--- a/src/main/webapp/go.html
+++ b/src/main/webapp/go.html
@@ -32,9 +32,10 @@
           <button class="button" id="start-button" type="button" onclick="startHunt()">Start Hunt</button>
           <button class="button" id="hint-button" type="button" onclick="getHint()">Get a Hint</button>
           <button class="button" id="proceed-button" type="button" onclick="proceed()">Proceed to Next Destination</button>
+          <button class="button" id="clear-hint-button" type="button" onclick="deleteMessage(HINT_DISPLAY)">Clear Hints</button>
         </div>
-        <div class="center-block hint-row" id="hint-area"></div>
       </div>
+      <div class="center-block hint-row" id="hint-area"></div>
       <div class="footer">
         <button class="button" type="button" onclick="exit()">Exit</button>
       </div>

--- a/src/main/webapp/go.js
+++ b/src/main/webapp/go.js
@@ -307,7 +307,7 @@ function displayNextReview() {
   const curIndex = hunt.getReviewIndex();
   if (curIndex < hunt.getReviews().length) {
     updateMessage(HINT_DISPLAY, 'Review of destination: ');
-    let cleanedReview = redactReview(hunt.getReviews()[curIndex].text);
+    const cleanedReview = redactReview(hunt.getReviews()[curIndex].text);
     updateMessage(HINT_DISPLAY, cleanedReview);
     hunt.setReviewIndex(curIndex + 1);
   }
@@ -319,7 +319,7 @@ function displayNextReview() {
  * @return {String} Redacted text
  */
 function redactReview(text) {
-  const re = new RegExp(hunt.getCurDestName(), "gi")
+  const re = new RegExp(hunt.getCurDestName(), 'gi');
   return text.replace(re, '[REDACTED]');
 }
 

--- a/src/main/webapp/go.js
+++ b/src/main/webapp/go.js
@@ -209,19 +209,28 @@ function getHint() { //eslint-disable-line
     updateMessage(HINT_DISPLAY, 'Hint #' + (hunt.getHintIndex()) +
         ': ' + nextHint);
   } else {
-    if (hunt.getPlaceID() == -1) {
-      autoGenerateHints();
-    } else {
-      getNextAutoHint();
-    }
+    getAutoHint();
   }
 }
 
 /**
- * Auto-generate hints using Places API, which take the form
- * either as a photo or a user review.
+ * Provides the user with the next auto-generated hint.
  */
-function autoGenerateHints() {
+function getAutoHint() {
+  // First time getting an auto hint for current destination.
+  if (hunt.getPlaceID() == -1) { 
+    generatePlaceID();
+  } else {
+    getNextAutoHint();
+  }
+}
+
+/**
+ * Get the first auto-generated hint for the current destination.
+ * This involves first retrieving the place ID for the current
+ * destination, before getting a new hint.
+ */
+function generatePlaceID() {
   const request = {
     query: hunt.getCurDestName(),
     fields: ['place_id'],
@@ -236,18 +245,18 @@ function autoGenerateHints() {
 }
 
 /**
- * Randomly display either a photo or a user review
- * from the destination.
+ * Gets a new auto-generated hint, assuming that the place
+ * ID for the current destination has already been determined.
  */
 function getNextAutoHint() {
   const random = Math.random();
-  if (random < 0.5) {
+  if (random < 0.5) { // Get a hint in the form of a photo
     if (hunt.getPhotos().length == 0) {
       generatePhotos();
     } else {
       displayNextPhoto();
     }
-  } else {
+  } else { // Get a hint in the form of a user review
     if (hunt.getReviews().length == 0) {
       generateReviews();
     } else {
@@ -257,7 +266,9 @@ function getNextAutoHint() {
 }
 
 /**
- * Generate photos for the destination from the Places API.
+ * Generate array of photos for the current destination using
+ * the Places API, which will later be used to retrieve and
+ * display photos.
  */
 function generatePhotos() {
   const photosRequest = {
@@ -281,11 +292,13 @@ function displayNextPhoto() {
     updateMessage(HINT_DISPLAY, 'Photo of destination: ');
     updatePhoto(HINT_DISPLAY, hunt.getPhotos()[curIndex]);
     hunt.setPhotoIndex(curIndex + 1);
-  }
+  } // If there are no more photos to display, do nothing
 }
 
 /**
- * Generate reviews for the destination from the Places API.
+ * Generate array of reviews for the current destination using
+ * the Places API, which will later be used to retrieve and
+ * display reviews.
  */
 function generateReviews() {
   const reviewsRequest = {
@@ -310,7 +323,7 @@ function displayNextReview() {
     const cleanedReview = redactReview(hunt.getReviews()[curIndex].text);
     updateMessage(HINT_DISPLAY, cleanedReview);
     hunt.setReviewIndex(curIndex + 1);
-  }
+  } // If there are no more reviews to display, do nothing
 }
 
 /**

--- a/src/main/webapp/go.js
+++ b/src/main/webapp/go.js
@@ -16,6 +16,8 @@
 const HINT_BUTTON = 'hint-button';
 const START_BUTTON = 'start-button';
 const PROCEED_BUTTON = 'proceed-button';
+const CLEAR_BUTTON = 'clear-hint-button';
+const SUBMIT_BUTTON = 'submit-button';
 
 // URLs that data should be fetched from.
 const DATA_URL = '/go-data';
@@ -40,6 +42,9 @@ const HUNT_PARAM = 'hunt_id';
 const PROCEED_FINAL_MSSG = 'Finish the Hunt';
 const CORRECT_MSSG = 'Correct!';
 const WRONG_MSSG = 'Wrong. Try again!';
+const EXIT_MSSG = 'Do you want to exit this scavenger hunt?' +
+    ' If so, make sure to bookmark this URL so you can return' +
+    ' to this page later.';
 
 // Interval durations.
 const MAP_INTERVAL_MS = 10000; // ten seconds
@@ -57,6 +62,7 @@ let hunt;
 let map;
 let hintClock;
 let huntID;
+let service;
 
 window.onload = function() {
   addScriptToHead();
@@ -100,7 +106,7 @@ function standardizeTime(num) {
 function addScriptToHead() {
   const newScript = document.createElement('script');
   newScript.src = 'https://maps.googleapis.com/maps/api/js?key=' +
-      config.MAP_KEY + '&callback=createMap';
+      config.MAP_KEY + '&libraries=places&callback=createMap';
   document.getElementsByTagName('head')[0].appendChild(newScript);
 }
 
@@ -178,18 +184,18 @@ function updateGeolocation() {
 }
 
 /**
- * Show or hide the hint button.
+ * Show or hide the hint button (as well as the clear hint button).
  * @param {boolean} hide Whether the proceed button should be hidden or shown.
- * Disable lint check because this will later be called by
- * handleDestinationAnswer(), updateToCurrentState(), and proceed().
- *
  */
-function toggleHintButton(hide) { //eslint-disable-line
+function toggleHintButton(hide) {
   const hintButton = document.getElementById(HINT_BUTTON);
+  const clearButton = document.getElementById(CLEAR_BUTTON);
   if (hide) {
     hintButton.classList.add(INVISIBLE_CLASS);
+    clearButton.classList.add(INVISIBLE_CLASS);
   } else {
     hintButton.classList.remove(INVISIBLE_CLASS);
+    clearButton.classList.remove(INVISIBLE_CLASS);
   }
 }
 
@@ -200,8 +206,122 @@ function toggleHintButton(hide) { //eslint-disable-line
 function getHint() { //eslint-disable-line
   const nextHint = hunt.getNextHint();
   if (nextHint != '') {
-    updateMessage(HINT_DISPLAY, nextHint);
+    updateMessage(HINT_DISPLAY, 'Hint #' + (hunt.getHintIndex()) +
+        ': ' + nextHint);
+  } else {
+    if (hunt.getPlaceID() == -1) {
+      autoGenerateHints();
+    } else {
+      getNextAutoHint();
+    }
   }
+}
+
+/**
+ * Auto-generate hints using Places API, which take the form
+ * either as a photo or a user review.
+ */
+function autoGenerateHints() {
+  let request = {
+    query: hunt.getCurDestName(),
+    fields: ['place_id'],
+  };
+  service = new google.maps.places.PlacesService(map);
+  service.findPlaceFromQuery(request, function(results, status) {
+    if (status === google.maps.places.PlacesServiceStatus.OK) {
+      hunt.setPlaceID(results[0].place_id);
+      getNextAutoHint();
+    }
+  });
+}
+
+/**
+ * Randomly display either a photo or a user review
+ * from the destination.
+ */
+function getNextAutoHint() {
+  const random = Math.random();
+  if (random < 0.5) {
+    if (hunt.getPhotos().length == 0) {
+      generatePhotos();
+    } else {
+      displayNextPhoto();
+    }
+  } else {
+    if (hunt.getReviews().length == 0) {
+      generateReviews();
+    } else {
+      displayNextReview();
+    }
+  }
+}
+
+/**
+ * Generate photos for the destination from the Places API.
+ */
+function generatePhotos() {
+  let detailsRequest = {
+    placeId: hunt.getPlaceID(),
+    fields: ['photo']
+  };
+  service.getDetails(detailsRequest,(place, status) => {
+    if (status == google.maps.places.PlacesServiceStatus.OK) {
+      hunt.setPhotos(place.photos);
+    }
+    displayNextPhoto();
+  });
+}
+
+/**
+ * Display the next photo hint that the user should see.
+ */
+function displayNextPhoto() {
+  let curIndex = hunt.getPhotoIndex();
+  if (curIndex < hunt.getPhotos().length) {
+    updateMessage(HINT_DISPLAY, 'Photo of destination: ');
+    updatePhoto(HINT_DISPLAY, hunt.getPhotos()[curIndex]);
+    hunt.setPhotoIndex(curIndex + 1);
+  }
+}
+
+/**
+ * Generate reviews for the destination from the Places API.
+ */
+function generateReviews() {
+  let detailsRequest = {
+    placeId: hunt.getPlaceID(),
+    fields: ['review']
+  };
+  service.getDetails(detailsRequest, (place, status) => {
+    if (status == google.maps.places.PlacesServiceStatus.OK) {
+      hunt.setReviews(place.reviews);
+    }
+    displayNextReview();
+  });
+}
+
+/**
+ * Display the next user review hint that the user should see.
+ */
+function displayNextReview() {
+  let curIndex = hunt.getReviewIndex();
+  if (curIndex < hunt.getReviews().length) {
+    updateMessage(HINT_DISPLAY, 'Review of destination: ');
+    updateMessage(HINT_DISPLAY, hunt.getReviews()[curIndex].text);
+    hunt.setReviewIndex(curIndex + 1);
+  }
+}
+
+/**
+ * Update {code@ display} to specified {code@ photo}.
+ * @param {String} display ID of element to be updated
+ * @param {String} photo Photo that should be added to display.
+ */
+function updatePhoto(display, photo) {
+  const message = document.getElementById(display);
+  const newImage = document.createElement('img');
+  newImage.src = photo.getUrl({maxWidth: 400, maxHeight: 400});
+  message.appendChild(newImage);
 }
 
 /**
@@ -249,8 +369,10 @@ function startHunt() { //eslint-disable-line
 function updateToCurrentState() {
   if (hunt.hasNotStarted()) {
     toggleHintButton(/* hide = */ true);
+    toggleSubmitForm(/* hide = */ true);
   } else { // The user has started the hunt, and needs to solve the riddle.
     delayHintButton();
+    toggleSubmitForm(/* hide = */ false);
     hideStartButton();
     updateMessage(RIDDLE_DISPLAY, 'Riddle: ' + hunt.getCurDestPuzzle());
   }
@@ -259,6 +381,23 @@ function updateToCurrentState() {
   for (let i = 0; i < hunt.getDestIndex(); i++) {
     addMarkerToMap(hunt.getDest(i).lat, hunt.getDest(i).lng,
         hunt.getDest(i).name);
+  }
+}
+
+/**
+ * Show or hide the submit form where the user inputs their guess
+ * for the destination.
+ * @param {boolean} hide Whether the form should be hidden or shown.
+ */
+function toggleSubmitForm(hide) {
+  const guessBar = document.getElementById(GUESS_INPUT);
+  const guessButton = document.getElementById(SUBMIT_BUTTON);
+  if (hide) {
+    guessBar.classList.add(INVISIBLE_CLASS);
+    guessButton.classList.add(INVISIBLE_CLASS);
+  } else {
+    guessBar.classList.remove(INVISIBLE_CLASS);
+    guessButton.classList.remove(INVISIBLE_CLASS);
   }
 }
 
@@ -309,8 +448,7 @@ function updateMessage(display, text) {
   if (display == HINT_DISPLAY) {
   // Special case for HINT_DISPLAY to avoid clearing out its existing contents
   // because it may already contain previous hints.
-    message.appendChild(createLine('Hint #' + (hunt.getHintIndex()) +
-        ': ' + text));
+    message.appendChild(createLine(text));
   } else {
     message.innerHTML = '';
     message.appendChild(createLine(text));
@@ -323,7 +461,8 @@ function updateMessage(display, text) {
  */
 function updateRiddleToFinalMessage() {
   const newLine = document.createElement('div');
-  let message = '<p> Congrats! You\'ve visited the following locations:</p>';
+  let message = '<p></p>'; // Extra line for readability.
+  message += '<p> Congrats! You\'ve visited the following locations:</p>';
   for (let i = 0; i < hunt.getNumItems(); i++) {
     message += '<p>' + sanitize(hunt.getDest(i).name) + ': ' +
         sanitize(hunt.getDest(i).description) + '</p>';
@@ -359,15 +498,17 @@ function proceed() { //eslint-disable-line
   if (hunt.getDestIndex() < hunt.getNumItems()) {
     updateMessage(RIDDLE_DISPLAY, 'Riddle: ' + hunt.getCurDestPuzzle());
     delayHintButton();
+    toggleSubmitForm(/* hide = */ false);
   } else {
     updateRiddleToFinalMessage();
     toggleHintButton(/* hide = */ true);
+    toggleSubmitForm(/* hide = */ true);
   }
   updateProgressBar();
   toggleProceedButton(/* hide = */ true);
   deleteMessage(SUBMIT_DISPLAY);
   deleteMessage(HINT_DISPLAY);
-  hunt.setHintIndex(0);
+  hunt.resetForNextDest();
 }
 
 /**
@@ -414,7 +555,7 @@ function sanitize(unsafeContent) {
  * Disable lint check because exit() is called from go.html.
  */
 function exit() { //eslint-disable-line
-  if (confirm('Exit hunt?')) {
+  if (confirm(EXIT_MSSG)) {
     window.location.replace(HOME_URL);
   }
 }

--- a/src/main/webapp/go.js
+++ b/src/main/webapp/go.js
@@ -222,7 +222,7 @@ function getHint() { //eslint-disable-line
  * either as a photo or a user review.
  */
 function autoGenerateHints() {
-  let request = {
+  const request = {
     query: hunt.getCurDestName(),
     fields: ['place_id'],
   };
@@ -260,11 +260,11 @@ function getNextAutoHint() {
  * Generate photos for the destination from the Places API.
  */
 function generatePhotos() {
-  let detailsRequest = {
+  const photosRequest = {
     placeId: hunt.getPlaceID(),
-    fields: ['photo']
+    fields: ['photo'],
   };
-  service.getDetails(detailsRequest,(place, status) => {
+  service.getDetails(photosRequest, (place, status) => {
     if (status == google.maps.places.PlacesServiceStatus.OK) {
       hunt.setPhotos(place.photos);
     }
@@ -276,7 +276,7 @@ function generatePhotos() {
  * Display the next photo hint that the user should see.
  */
 function displayNextPhoto() {
-  let curIndex = hunt.getPhotoIndex();
+  const curIndex = hunt.getPhotoIndex();
   if (curIndex < hunt.getPhotos().length) {
     updateMessage(HINT_DISPLAY, 'Photo of destination: ');
     updatePhoto(HINT_DISPLAY, hunt.getPhotos()[curIndex]);
@@ -288,11 +288,11 @@ function displayNextPhoto() {
  * Generate reviews for the destination from the Places API.
  */
 function generateReviews() {
-  let detailsRequest = {
+  const reviewsRequest = {
     placeId: hunt.getPlaceID(),
-    fields: ['review']
+    fields: ['review'],
   };
-  service.getDetails(detailsRequest, (place, status) => {
+  service.getDetails(reviewsRequest, (place, status) => {
     if (status == google.maps.places.PlacesServiceStatus.OK) {
       hunt.setReviews(place.reviews);
     }
@@ -304,7 +304,7 @@ function generateReviews() {
  * Display the next user review hint that the user should see.
  */
 function displayNextReview() {
-  let curIndex = hunt.getReviewIndex();
+  const curIndex = hunt.getReviewIndex();
   if (curIndex < hunt.getReviews().length) {
     updateMessage(HINT_DISPLAY, 'Review of destination: ');
     updateMessage(HINT_DISPLAY, hunt.getReviews()[curIndex].text);

--- a/src/main/webapp/go.js
+++ b/src/main/webapp/go.js
@@ -307,9 +307,20 @@ function displayNextReview() {
   const curIndex = hunt.getReviewIndex();
   if (curIndex < hunt.getReviews().length) {
     updateMessage(HINT_DISPLAY, 'Review of destination: ');
-    updateMessage(HINT_DISPLAY, hunt.getReviews()[curIndex].text);
+    let cleanedReview = redactReview(hunt.getReviews()[curIndex].text);
+    updateMessage(HINT_DISPLAY, cleanedReview);
     hunt.setReviewIndex(curIndex + 1);
   }
+}
+
+/**
+ * Redact all references in text to the destination name.
+ * @param {String} text Text to be redacted
+ * @return {String} Redacted text
+ */
+function redactReview(text) {
+  const re = new RegExp(hunt.getCurDestName(), "gi")
+  return text.replace(re, '[REDACTED]');
 }
 
 /**

--- a/src/main/webapp/go.js
+++ b/src/main/webapp/go.js
@@ -218,7 +218,7 @@ function getHint() { //eslint-disable-line
  */
 function getAutoHint() {
   // First time getting an auto hint for current destination.
-  if (hunt.getPlaceID() == -1) { 
+  if (hunt.getPlaceID() == -1) {
     generatePlaceID();
   } else {
     getNextAutoHint();

--- a/src/main/webapp/scavengerHuntManager.js
+++ b/src/main/webapp/scavengerHuntManager.js
@@ -18,6 +18,11 @@ class ScavengerHuntManager { //eslint-disable-line
     this.destIndex = destIndex;
     this.hintIndex = hintIndex;
     this.huntArr = huntArr;
+    this.photoIndex = 0;
+    this.reviewIndex = 0;
+    this.placeID = -1;
+    this.photos = [];
+    this.reviews = [];
   }
 
   /**
@@ -42,6 +47,62 @@ class ScavengerHuntManager { //eslint-disable-line
       }
     }
     return '';
+  }
+
+  /**
+   * @param {array} newPhotos Array that photos should be modified to.
+   */
+  setPhotos(newPhotos) {
+    this.photos = newPhotos;
+  }
+
+  /**
+   * @return {array} Photos corresponding to current destination.
+   */
+  getPhotos() {
+    return this.photos;
+  }
+
+  /**
+   * @param {array} newReviews Array that reviews should be modified to.
+   */
+  setReviews(newReviews) {
+    this.reviews = newReviews;
+  }
+
+  /**
+   * @return {array} Reviews corresponding to current destination.
+   */
+  getReviews() {
+    return this.reviews;
+  }
+
+  /**
+   * @return {int} Place ID corresponding to current destination.
+   */
+  getPlaceID() {
+    return this.placeID;
+  }
+
+  /**
+   * @param {int} newID Place ID of the current destination.
+   */
+  setPlaceID(newID) {
+    this.placeID = newID;
+  }
+
+  /**
+   * Reset all destination-specific fields to their default state.
+   * This method is called when the user moves on to a new
+   * destination.
+   */
+  resetForNextDest() {
+    hunt.setHintIndex(0);
+    hunt.setPhotoIndex(0);
+    hunt.setReviewIndex(0);
+    hunt.setPhotos([]);
+    hunt.setReviews([]);
+    hunt.setPlaceID(-1);
   }
 
   /**
@@ -146,6 +207,34 @@ class ScavengerHuntManager { //eslint-disable-line
    */
   setHintIndex(newIndex) {
     this.hintIndex = newIndex;
+  }
+
+  /**
+   * @return {int} Index of the photo hint the user will receive.
+   */
+  getPhotoIndex() {
+    return this.photoIndex;
+  }
+
+  /**
+   * @param {int} newIndex Value photoIndex should be modified to.
+   */
+  setPhotoIndex(newIndex) {
+    this.photoIndex = newIndex;
+  }
+
+  /**
+   * @return {int} Index of the review hint the user will receive.
+   */
+  getReviewIndex() {
+    return this.reviewIndex;
+  }
+
+  /**
+   * @param {int} newIndex Value reviewIndex should be modified to.
+   */
+  setReviewIndex(newIndex) {
+    this.reviewIndex = newIndex;
   }
 
   /**

--- a/src/main/webapp/scavengerHuntManager.js
+++ b/src/main/webapp/scavengerHuntManager.js
@@ -97,12 +97,12 @@ class ScavengerHuntManager { //eslint-disable-line
    * destination.
    */
   resetForNextDest() {
-    hunt.setHintIndex(0);
-    hunt.setPhotoIndex(0);
-    hunt.setReviewIndex(0);
-    hunt.setPhotos([]);
-    hunt.setReviews([]);
-    hunt.setPlaceID(-1);
+    this.setHintIndex(0);
+    this.setPhotoIndex(0);
+    this.setReviewIndex(0);
+    this.setPhotos([]);
+    this.setReviews([]);
+    this.setPlaceID(-1);
   }
 
   /**


### PR DESCRIPTION
- Implementation autogeneration of hints using Places API.
  - All instances where the user review directly contains the destination name is replaced with "[REDACTED]."
- Add pop-up message when user clicks the exit button that reminds them to save or bookmark the link if they want to return to the hunt later.
- Selectively display the user input form.
- Bold the riddle for readability, and reformat the way that hints are displayed to account for the increase in height of the display.

Start of hunt:
![Screenshot 2020-08-17 at 11 47 41 AM](https://user-images.githubusercontent.com/43889831/90434824-e9235a80-e082-11ea-9e0b-3b512ce24e3a.png)

Autogenerating hints (reviews):
![Screenshot 2020-08-17 at 11 49 53 AM](https://user-images.githubusercontent.com/43889831/90434682-b11c1780-e082-11ea-9867-35e54e2c9d1a.png)

Autogenerating hints (photos):
![Screenshot 2020-08-17 at 11 52 39 AM](https://user-images.githubusercontent.com/43889831/90434717-c09b6080-e082-11ea-8eff-545d9cde5868.png)

After completing the hunt:
![Screenshot 2020-08-17 at 12 03 56 PM](https://user-images.githubusercontent.com/43889831/90434775-d90b7b00-e082-11ea-98ec-ebe8e01a20f7.png)
