### PR TITLE
Allow more than 1500 bytes in datastore

### DIFF
--- a/src/main/java/com/google/sps/servlets/GenerateServlet.java
+++ b/src/main/java/com/google/sps/servlets/GenerateServlet.java
@@ -179,7 +179,6 @@ public class GenerateServlet extends HttpServlet {
     Text scavHuntText = new Text(jsonScavHunt);
     Entity scavHuntEntity = new Entity(Constants.SCAVENGER_HUNT_ENTITY);
     scavHuntEntity.setProperty(Constants.SCAVENGER_HUNT_ENTITY, scavHuntText);
-   // scavHuntEntity.setUnindexedProperty(Constants.SCAVENGER_HUNT_ENTITY, jsonScavHunt);
     datastore.put(scavHuntEntity);
 
     return scavHuntEntity.getKey().getId();

--- a/src/main/java/com/google/sps/servlets/GenerateServlet.java
+++ b/src/main/java/com/google/sps/servlets/GenerateServlet.java
@@ -19,6 +19,7 @@ import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Text;
 import com.google.gson.Gson;
 import com.google.sps.data.Destination;
 import com.google.sps.data.HuntItem;
@@ -175,8 +176,10 @@ public class GenerateServlet extends HttpServlet {
   /* Store Scavenger Hunt object in Datastore, return Id of created Hunt. */
   public long writeToDataStore(ScavengerHunt scavHunt) {
     String jsonScavHunt = new Gson().toJson(scavHunt);
+    Text scavHuntText = new Text(jsonScavHunt);
     Entity scavHuntEntity = new Entity(Constants.SCAVENGER_HUNT_ENTITY);
-    scavHuntEntity.setProperty(Constants.SCAVENGER_HUNT_ENTITY, jsonScavHunt);
+    scavHuntEntity.setProperty(Constants.SCAVENGER_HUNT_ENTITY, scavHuntText);
+   // scavHuntEntity.setUnindexedProperty(Constants.SCAVENGER_HUNT_ENTITY, jsonScavHunt);
     datastore.put(scavHuntEntity);
 
     return scavHuntEntity.getKey().getId();

--- a/src/main/java/com/google/sps/servlets/GoDataServlet.java
+++ b/src/main/java/com/google/sps/servlets/GoDataServlet.java
@@ -56,7 +56,8 @@ public class GoDataServlet extends HttpServlet {
 
       // Update index of scavenger hunt.
       ScavengerHunt hunt =
-          gson.fromJson(((Text) huntEntity.getProperty(Constants.HUNT_VAL)).getValue(), ScavengerHunt.class);
+          gson.fromJson(
+              ((Text) huntEntity.getProperty(Constants.HUNT_VAL)).getValue(), ScavengerHunt.class);
       hunt.updateIndex(index);
 
       // Convert hunt to JSON string and put into Datastore

--- a/src/main/java/com/google/sps/servlets/GoDataServlet.java
+++ b/src/main/java/com/google/sps/servlets/GoDataServlet.java
@@ -19,6 +19,7 @@ import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.Text;
 import com.google.gson.Gson;
 import com.google.sps.data.ScavengerHunt;
 import java.io.IOException;
@@ -55,12 +56,13 @@ public class GoDataServlet extends HttpServlet {
 
       // Update index of scavenger hunt.
       ScavengerHunt hunt =
-          gson.fromJson((String) huntEntity.getProperty(Constants.HUNT_VAL), ScavengerHunt.class);
+          gson.fromJson(((Text) huntEntity.getProperty(Constants.HUNT_VAL)).getValue(), ScavengerHunt.class);
       hunt.updateIndex(index);
 
       // Convert hunt to JSON string and put into Datastore
       String huntStr = gson.toJson(hunt);
-      huntEntity.setProperty(Constants.HUNT_VAL, huntStr);
+      Text huntStrText = new Text(huntStr);
+      huntEntity.setProperty(Constants.HUNT_VAL, huntStrText);
       datastore.put(huntEntity);
     } catch (Exception e) {
     }
@@ -84,7 +86,7 @@ public class GoDataServlet extends HttpServlet {
     if (huntEntity == null) {
       response.getWriter().println(ERROR_MSSG);
     } else {
-      String json = (String) huntEntity.getProperty(Constants.HUNT_VAL);
+      String json = ((Text) huntEntity.getProperty(Constants.HUNT_VAL)).getValue();
       response.getWriter().println(json);
     }
   }


### PR DESCRIPTION
* Switch from using json strings to wrapping json strings in Text objects, and then storing in datastore
* In GoDataServlet, retrieve objects as Text rather than Strings